### PR TITLE
Use resources

### DIFF
--- a/booking-api.apib
+++ b/booking-api.apib
@@ -37,7 +37,7 @@ Details for any Hotel object in the database.
 
         [
             {
-                "id": "7f0ddae0ac541bd1",
+                "resource": "http://booking-api.windingtree.com/hotels/7f0ddae0ac541bd1",
                 "name": "Vista del Pinnella Pass",
                 "description": "Long text of describing this venue...",
                 "created": "2017-04-25T12:56:29.310Z",
@@ -90,6 +90,7 @@ any price.
     + Body
 
             {
+                "resource": "http://booking-api.windingtree.com/upload-inventory/a68da69c5644ec70",
                 "hotel": "http://booking-api.windingtree.com/hotels/7f0ddae0ac541bd1",
                 "min_guests": 1,
                 "max_guests": 2,
@@ -133,7 +134,7 @@ Booking of a room in one hotel.
     + Body
 
             {
-                "id": "e0af617e28919045",
+                "resource": "http://booking-api.windingtree.com/upload-booking/e0af617e28919045",
                 "hotel": "http://booking-api.windingtree.com/hotels/7f0ddae0ac541bd1",
                 "date_from": "2017-05-05",
                 "date_till": "2017-05-06",


### PR DESCRIPTION
use full `resource` as an identificator instead of plain `id`